### PR TITLE
chore(dep-dev): add peer dependency @aws-sdk/util-dynamodb

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@aws-sdk/lib-dynamodb": "3.21.0"
   },
   "devDependencies": {
+    "@aws-sdk/util-dynamodb": "^3.21.0",
     "@types/jest": "26.0.24",
     "aws-sdk-client-mock": "0.5.3",
     "jest": "27.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -529,6 +529,13 @@
     "@aws-sdk/is-array-buffer" "3.20.0"
     tslib "^2.0.0"
 
+"@aws-sdk/util-dynamodb@^3.21.0":
+  version "3.21.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-dynamodb/-/util-dynamodb-3.21.0.tgz#d00910213ba15e0883a53854417dc289bb4fc100"
+  integrity sha512-JPRgtH7ZRkyXWSV3Q2rqshGZU2aY2nwD/tQFWSXmoxmd9MJBqKE1lMz+a1TTqXMoDc9ReZym1BtKOKptUG/o9A==
+  dependencies:
+    tslib "^2.0.0"
+
 "@aws-sdk/util-hex-encoding@3.20.0":
   version "3.20.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.20.0.tgz#ca3b77a58117365ce9bd317ce0fd62fde53fedab"


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/trivikr/aws-sdk-client-mock-test/issues/1

*Description of changes:*
The error was thrown while running tests, as peer dependency `@aws-sdk/util-dynamodb` was not installed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
